### PR TITLE
mpibind: fix input parameter check

### DIFF
--- a/src/mpibind.c
+++ b/src/mpibind.c
@@ -1282,7 +1282,7 @@ int mpibind(mpibind_t *hdl)
   }
   
   /* Input parameters check */
-  if (hdl->ntasks <= 0 || hdl->nthreads < 0) {
+  if (hdl->ntasks <= 0 || hdl->in_nthreads < 0) {
     fprintf(stderr, "Error: ntasks %d or nthreads %d out of range\n",
 	    hdl->ntasks, hdl->in_nthreads);
     return 1;


### PR DESCRIPTION
Fix a parameter check where hdl->nthreads was being checked instead of hdl->in_nthreads. In the broken version, the mpibind algorithm wouldn't error out when in_nthreads was set to -1

Closes #2 