### PR TITLE
Add mpibind utility functions (1/3)

### DIFF
--- a/flux/plugin.c
+++ b/flux/plugin.c
@@ -135,22 +135,6 @@ int mpibind_task_init(flux_plugin_t *p, const char *topic,
   return 0;
 }
 
-
-/* 
- * Apply mpibind affinity for task `taskid`
- */
-static
-int mpibind_apply(mpibind_t *mph, int taskid)
-{
-  hwloc_bitmap_t *core_sets = mpibind_get_cpus(mph);
-  hwloc_topology_t topo = mpibind_get_topology(mph);
-  
-  if (hwloc_set_cpubind(topo, core_sets[taskid], 0) < 0)
-    shell_log_errno("hwloc_set_cpubind");
-  
-  return 0;
-}
-
 /*
  * Printing mpibind's mapping: 
  * To get rid of the shell_log() prefix, e.g., 

--- a/src/mpibind-priv.h
+++ b/src/mpibind-priv.h
@@ -77,6 +77,7 @@ struct mpibind_t {
   hwloc_bitmap_t *cpus; 
   hwloc_bitmap_t *gpus;
   char ***gpus_usr; 
+  char **cpus_usr;
 
   /* Environment variables */
   int nvars;

--- a/src/mpibind.c
+++ b/src/mpibind.c
@@ -917,3 +917,14 @@ char** mpibind_get_env_var_names(mpibind_t *handle, int *count)
 }
 
 
+int mpibind_apply(mpibind_t *handle, int taskid)
+{
+  int rc;
+  hwloc_bitmap_t *core_sets = mpibind_get_cpus(handle);
+  hwloc_topology_t topo = mpibind_get_topology(handle);
+  
+  if ((rc = hwloc_set_cpubind(topo, core_sets[taskid], 0)) < 0)
+    return rc;
+  
+  return 0;
+}

--- a/src/mpibind.h
+++ b/src/mpibind.h
@@ -139,6 +139,11 @@ extern "C" {
    */ 
   hwloc_bitmap_t* mpibind_get_cpus(mpibind_t *handle);
   /*
+   * Return an array with the CPUs assigned to the 
+   * given task. The size of the array is set in 'ncpus'. 
+   */
+  char* mpibind_get_cpus_ptask(mpibind_t *handle, int taskid); 
+  /*
    * Return an array with the GPUs assigned to the 
    * given task. The size of the array is set in 'ngpus'. 
    */

--- a/src/mpibind.h
+++ b/src/mpibind.h
@@ -261,6 +261,10 @@ extern "C" {
    * mpibind handle.
    */
   int mpibind_get_restrict_type(mpibind_t *handle);
+  /* 
+   * Apply mpibind affinity for task `taskid`
+   */
+  int mpibind_apply(mpibind_t *handle, int taskid);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
# PR 1/3 of mpibind for Python

## Adding functionality to the mpibind C library
1. Add the mpibind_apply function which applies a handle's mapping to a provided taskid
2. Add the mpibind_get_cpus_ptask function that allows users to access the cpu mapping for a given task as a string
