### PR TITLE
set FLUX_SHELL_PLUGIN_NAME for mpibind plugin

### DIFF
--- a/flux/plugin.c
+++ b/flux/plugin.c
@@ -1,3 +1,5 @@
+#define FLUX_SHELL_PLUGIN_NAME "mpibind"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpibind.h>
@@ -60,7 +62,7 @@
  *   such as "mpibind". If you don't overwrite the affinity module, you'll 
  *   have to disable the module from within this plugin (see mpibind_init)
  */
-#define PLUGIN_NAME "mpibind"
+#define PLUGIN_NAME FLUX_SHELL_PLUGIN_NAME
 
 #define LONG_STR_SIZE 1024
 


### PR DESCRIPTION
Future versions of flux-core will require FLUX_SHELL_PLUGIN_NAME
to be defined before including flux/shell.h. This macro will be used
to define the component name for logging messages, so if it is missing
a compilation error will result.

Since it does no harm to define it when unneeded, set it to "mpibind"
at the top of the Flux shell plugin definition to avoid future compilation
errors when building against newer flux-core installations.